### PR TITLE
增加了获取在线简历的功能

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,11 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-    <data-source source="LOCAL" name="shixi@localhost" uuid="3c8390cf-af2f-48dd-b444-4e9976644e62">
-      <driver-ref>mysql.8</driver-ref>
+    <data-source source="LOCAL" name="0@192.168.202.128" uuid="e471cb75-02da-409e-a3b3-1b5b77b29839">
+      <driver-ref>redis</driver-ref>
       <synchronize>true</synchronize>
-      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
-      <jdbc-url>jdbc:mysql://localhost:3306/shixi</jdbc-url>
+      <jdbc-driver>jdbc.RedisDriver</jdbc-driver>
+      <jdbc-url>jdbc:redis://192.168.202.128:6379/0</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+    <data-source source="LOCAL" name="shixi@127.0.0.1" uuid="2ced6699-8008-4c3f-b87c-e69b1189b6ae">
+      <driver-ref>mysql</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <jdbc-driver>com.mysql.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://127.0.0.1:3306/shixi?useSSL=false&amp;serverTimezone=UTC</jdbc-url>
       <jdbc-additional-properties>
         <property name="com.intellij.clouds.kubernetes.db.host.port" />
         <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-2025/05/17 次提交
-1.新增studentcontorller功能两个：发送验证码和使用验证码登录
-2.新增util包下多个工具类：两个拦截器配置类类（可以去看代码看不懂问我）
-3.util：两个regex类负责防御性编程，校验前端数据的合法性
-4.util：新增studentholder类负责将学生基础信息缓存在threallocal中方便返回前端
-5.config：一个拦截器，负责调用两个拦截器配置类
+# 日志
+## 2025/05/17 次提交
+1. 新增studentcontorller功能两个：发送验证码和使用验证码登录
+2. 新增util包下多个工具类：两个拦截器配置类类（可以去看代码看不懂问我）
+3. util：两个regex类负责防御性编程，校验前端数据的合法性
+4. util：新增studentholder类负责将学生基础信息缓存在threallocal中方便返回前端
+5. config：一个拦截器，负责调用两个拦截器配置类
+---
+## 2025/05/18 陈永川
+主要做了如下事情
+1. 新增一个controller类`OnlineResumeController`，该类负责处理在线简历的请求
+2. 新增两个实体类`OnlineResume`和`ResumeExperience`,分别用于存储在线简历中的基本信息和工作经历，项目经历等信息
+3. 新增两张表 在线简历表`online_resume`和在线简历经历表`resume_experience`对应上述的两个新增实体类，建表语句详见`\src\main\resources\SQL\init.sql`的后两张表
+4. 新建了上述两张表对应的Mapper类
+5. 完成了获取在线简历的接口，详情见`\src\main\resources\document\api文档.md`里的内容
+6. 整理了项目至今用到的数据库表建表语句，一共四张，在上面说的`init.sql`里，后续有建表可以在里面加，方便开发

--- a/src/main/java/com/ShiXi/controller/OnlineResumeController.java
+++ b/src/main/java/com/ShiXi/controller/OnlineResumeController.java
@@ -1,0 +1,29 @@
+package com.ShiXi.controller;
+
+import com.ShiXi.dto.Result;
+import com.ShiXi.service.OnlineResumeService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Resource;
+
+/**
+ * 在线简历相关接口
+ */
+@Slf4j
+@RestController
+@RequestMapping("/student")
+public class OnlineResumeController {
+    @Resource
+    private OnlineResumeService onlineResumeService;
+    /**
+     * 获取当前用户在线简历信息
+     * @return 在线简历信息的vo类
+     */
+    @GetMapping("/me/myInfo")
+    public Result getOnlineResume() {
+        return onlineResumeService.getOnlineResume();
+    }
+}

--- a/src/main/java/com/ShiXi/entity/OnlineResume.java
+++ b/src/main/java/com/ShiXi/entity/OnlineResume.java
@@ -1,0 +1,51 @@
+package com.ShiXi.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 在线简历实体类
+ */
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Accessors(chain = true)
+@TableName("online_resume")
+public class OnlineResume implements Serializable {
+    @TableId(value = "id", type = IdType.AUTO)
+
+    private Long id; // ID
+
+    private Long userId; // 学生ID, 外键
+
+    private String name; // 姓名
+
+    private String icon;//头像
+
+    private String schoolName; // 学校名称
+
+    private String major; // 专业名称
+
+    private LocalDate graduationDate; // 毕业时间，格式：YYYY-MM-DD
+
+    private Integer age; // 年龄
+
+    private String phone; // 联系电话
+
+    private String wechat; // 微信号
+
+    private String educationLevel; // 学历（本科、大专、硕士、博士、其他）
+
+    private String advantages; // 个人优势
+
+    private LocalDateTime createTime; // 创建时间
+
+    private LocalDateTime updateTime; // 更新时间
+}

--- a/src/main/java/com/ShiXi/entity/ResumeExperience.java
+++ b/src/main/java/com/ShiXi/entity/ResumeExperience.java
@@ -1,0 +1,32 @@
+package com.ShiXi.entity;
+
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
+import com.baomidou.mybatisplus.annotation.TableName;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.Accessors;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@Accessors(chain = true)
+@TableName("resume_experience")
+public class ResumeExperience implements Serializable {
+    @TableId(value = "id", type = IdType.AUTO)
+    private Long id; // 经历ID
+
+    private Long onlineResumeId; // 所属在线简历的ID
+
+    private String type; // 经历类型（工作、实习、项目、作品集）
+
+    private String description; // 经历描述，长文本
+
+    private String link; // 作品的链接，允许为空
+
+    private LocalDateTime createTime; // 创建时间
+
+    private LocalDateTime updateTime; // 更新时间
+}

--- a/src/main/java/com/ShiXi/mapper/OnlineResumeMapper.java
+++ b/src/main/java/com/ShiXi/mapper/OnlineResumeMapper.java
@@ -1,0 +1,12 @@
+package com.ShiXi.mapper;
+
+import com.ShiXi.entity.OnlineResume;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 在线简历mapper类
+ */
+@Mapper
+public interface OnlineResumeMapper extends BaseMapper<OnlineResume> {
+}

--- a/src/main/java/com/ShiXi/mapper/ResumeExperienceMapper.java
+++ b/src/main/java/com/ShiXi/mapper/ResumeExperienceMapper.java
@@ -1,0 +1,12 @@
+package com.ShiXi.mapper;
+
+import com.ShiXi.entity.ResumeExperience;
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * 在线简历经历表的mapper类
+ */
+@Mapper
+public interface ResumeExperienceMapper extends BaseMapper<ResumeExperience> {
+}

--- a/src/main/java/com/ShiXi/service/OnlineResumeService.java
+++ b/src/main/java/com/ShiXi/service/OnlineResumeService.java
@@ -1,0 +1,11 @@
+package com.ShiXi.service;
+
+import com.ShiXi.dto.Result;
+
+public interface OnlineResumeService {
+    /**
+     * 获取在线简历
+     * @return 在线简历的vo类
+     */
+    Result getOnlineResume();
+}

--- a/src/main/java/com/ShiXi/service/impl/OnlineResumeServiceImpl.java
+++ b/src/main/java/com/ShiXi/service/impl/OnlineResumeServiceImpl.java
@@ -1,0 +1,65 @@
+package com.ShiXi.service.impl;
+
+import com.ShiXi.dto.Result;
+import com.ShiXi.entity.OnlineResume;
+import com.ShiXi.entity.ResumeExperience;
+import com.ShiXi.mapper.OnlineResumeMapper;
+import com.ShiXi.mapper.ResumeExperienceMapper;
+import com.ShiXi.service.OnlineResumeService;
+import com.ShiXi.utils.UserHolder;
+import com.ShiXi.vo.OnlineResumeVO;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeanUtils;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+@Slf4j
+@Service
+public class OnlineResumeServiceImpl implements OnlineResumeService {
+    @Resource
+    private OnlineResumeMapper onlineResumeMapper;
+    @Resource
+    private ResumeExperienceMapper resumeExperienceMapper;
+
+    /**
+     * 获取在线简历
+     *
+     * @return 在线简历的vo类
+     */
+    @Override
+    public Result getOnlineResume() {
+        //获取当前用户id
+        Long id = UserHolder.getUser().getId();
+        //根据当前用户id查出在线简历
+        QueryWrapper<OnlineResume> queryForResume = new QueryWrapper<>();
+        queryForResume.eq("user_id", id);
+        OnlineResume onlineResume = onlineResumeMapper.selectOne(queryForResume);
+        //根据在线简历id查出在线简历的简历经历
+        QueryWrapper<ResumeExperience> queryForExperience = new QueryWrapper<>();
+        queryForExperience.eq("online_resume_id", onlineResume.getId());
+        List<ResumeExperience> resumeExperiences = resumeExperienceMapper.selectList(queryForExperience);
+        //进行组装
+        OnlineResumeVO onlineResumeVO = new OnlineResumeVO();
+        BeanUtils.copyProperties(onlineResume, onlineResumeVO);
+        for (ResumeExperience experience : resumeExperiences) {
+            switch (experience.getType()) {
+                case "实习":
+                    onlineResumeVO.getInternshipExperiences().add(experience);
+                    break;
+                case "工作":
+                    onlineResumeVO.getWorkExperiences().add(experience);
+                    break;
+                case "项目":
+                    onlineResumeVO.getProjectExperiences().add(experience);
+                    break;
+                case "作品集":
+                    onlineResumeVO.getPortfolioExperiences().add(experience);
+                    break;
+            }
+        }
+        return Result.ok(onlineResumeVO);
+    }
+}

--- a/src/main/java/com/ShiXi/vo/OnlineResumeVO.java
+++ b/src/main/java/com/ShiXi/vo/OnlineResumeVO.java
@@ -1,0 +1,38 @@
+package com.ShiXi.vo;
+
+import com.ShiXi.entity.ResumeExperience;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 在线简历的vo类，用于组合在线简历的基础信息和实习经历等信息返回给前端
+ */
+@Data
+@EqualsAndHashCode
+public class OnlineResumeVO {
+    // 基础简历信息
+    private Long id;
+    private Long userId;
+    private String name;
+    private String schoolName;
+    private String major;
+    private LocalDate graduationDate;
+    private Integer age;
+    private String phone;
+    private String wechat;
+    private String educationLevel;
+    private String advantages;
+    private LocalDateTime createTime;
+    private LocalDateTime updateTime;
+
+    // 分类后的经历集合
+    private List<ResumeExperience> internshipExperiences = new ArrayList<>();//实习
+    private List<ResumeExperience> workExperiences = new ArrayList<>();//工作
+    private List<ResumeExperience> projectExperiences = new ArrayList<>();//项目
+    private List<ResumeExperience> portfolioExperiences = new ArrayList<>();//作品集
+}

--- a/src/main/resources/SQL/init.sql
+++ b/src/main/resources/SQL/init.sql
@@ -1,0 +1,69 @@
+DROP DATABASE IF EXISTS shixi;
+CREATE DATABASE shixi;
+USE shixi;
+-- 用户表
+CREATE TABLE `user`
+(
+    `id`         BIGINT       NOT NULL AUTO_INCREMENT COMMENT '用户ID',
+    `phone`      VARCHAR(20)  NOT NULL COMMENT '电话号码',
+    `password`   VARCHAR(255) NOT NULL COMMENT '密码',
+    `nick_name`   VARCHAR(100) NOT NULL COMMENT '昵称',
+    `icon`       VARCHAR(255) DEFAULT '' COMMENT '头像',
+    `create_time` DATETIME     DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    `update_time` DATETIME     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    PRIMARY KEY (`id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='用户表';
+
+-- 插入测试用户
+INSERT INTO `user` (`phone`, `password`, `nick_name`, `icon`)
+VALUES ('18378059289', 'password', 'admin', 'https://**');
+-- 学生基本信息表
+CREATE TABLE student_basic_info
+(
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '学生基本信息 ID',
+    user_id           BIGINT       NOT NULL COMMENT '与user的id绑定',
+    name              VARCHAR(255) NOT NULL COMMENT '姓名',
+    gender            VARCHAR(10) COMMENT '性别，例如：男 / 女',
+    birth_date        VARCHAR(10) COMMENT '出生年月，格式为 yyyy/MM，例如：2003/10',
+    highest_education VARCHAR(50) COMMENT '最高学历，例如：本科',
+    school_name       VARCHAR(255) COMMENT '学校名称，例如：华南理工大学',
+    major             VARCHAR(255) COMMENT '专业名称，例如：计算机科学与技术',
+    study_period      VARCHAR(50) COMMENT '就读时间',
+    expected_position VARCHAR(255) COMMENT '期望职位，例如：互联网-产品实习生',
+    create_time       DATETIME COMMENT '创建时间',
+    update_time       DATETIME COMMENT '更新时间',
+    INDEX idx_user_id (user_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='学生基本信息表';
+-- 在线简历表
+CREATE TABLE online_resume
+(
+    id              BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '简历ID',
+    user_id      BIGINT                                        NOT NULL COMMENT '用户ID,外键',
+    name            VARCHAR(100)                                  NOT NULL COMMENT '姓名',
+    icon            VARCHAR(255) DEFAULT '' COMMENT '用户头像路径，默认空字符串', -- 考虑到简历可能要用证件照，这里不用student表里面的
+    school_name     VARCHAR(255)                                  NOT NULL COMMENT '学校名称',
+    major           VARCHAR(255)                                  NOT NULL COMMENT '专业名称',
+    graduation_date DATE COMMENT '毕业时间，格式：YYYY-MM-DD',
+    age             INT COMMENT '年龄',
+    phone           VARCHAR(20) COMMENT '联系电话',
+    wechat          VARCHAR(50) COMMENT '微信号',
+    education_level ENUM ('本科', '大专', '硕士', '博士', '其他') NOT NULL COMMENT '学历（本科、大专等）',
+    advantages      TEXT COMMENT '个人优势，长文本',
+    create_time     DATETIME     DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    update_time     DATETIME     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间'
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='在线简历表';
+-- 在线简历经历表
+CREATE TABLE resume_experience
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY COMMENT '经历ID',
+    online_resume_id BIGINT                                  NOT NULL COMMENT '所属在线简历的ID',
+    type             ENUM ('工作', '实习', '项目', '作品集') NOT NULL COMMENT '经历类型（工作、实习、项目、作品集）',
+    description      TEXT COMMENT '经历描述，长文本',
+    link             VARCHAR(512) DEFAULT NULL COMMENT '可选的链接，允许为空',
+    create_time      DATETIME     DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    update_time      DATETIME     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间'
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4 COMMENT ='在线简历经历表';

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,11 +8,11 @@ spring:
     driver-class-name: com.mysql.jdbc.Driver
     url: jdbc:mysql://127.0.0.1:3306/shixi?useSSL=false&serverTimezone=UTC
     username: root
-    password: 12345678
+    password: 1234
   redis:
-    host: 192.168.36.129
+    host: 192.168.202.128
     port: 6379
-    password: 111111
+    password: 1234
     lettuce:
       pool:
         max-active: 10

--- a/src/main/resources/document/api文档.md
+++ b/src/main/resources/document/api文档.md
@@ -1,0 +1,45 @@
+# 接口文档
+---
+## 获取在线简历信息接口
+### 请求信息
+
+- **请求类型**：`GET`
+- **请求路径**：`/student/me/myInfo`
+- **请求参数**：无
+
+### 返回示例
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": 1,
+    "userId": 1,
+    "name": "cyc",
+    "schoolName": "华南理工大学",
+    "major": "CS",
+    "graduationDate": "2027-07-01",
+    "age": 19,
+    "phone": "18378059289",
+    "wechat": "cloogcyc",
+    "educationLevel": "本科",
+    "advantages": "是个好人",
+    "createTime": "2025-05-18T11:34:38",
+    "updateTime": "2025-05-18T11:34:48",
+    "internshipExperiences": [
+      {
+        "id": 1,
+        "onlineResumeId": 1,
+        "type": "实习",
+        "description": "Java开发",
+        "link": "https://**",
+        "createTime": "2025-05-18T11:35:20",
+        "updateTime": "2025-05-18T11:35:20"
+      }
+    ],
+    "workExperiences": [],
+    "projectExperiences": [],
+    "portfolioExperiences": []
+  }
+}
+```


### PR DESCRIPTION
主要做了如下事情
1. 新增一个controller类`OnlineResumeController`，该类负责处理在线简历的请求
2. 新增两个实体类`OnlineResume`和`ResumeExperience`,分别用于存储在线简历中的基本信息和工作经历，项目经历等信息
3. 新增两张表 在线简历表`online_resume`和在线简历经历表`resume_experience`对应上述的两个新增实体类，建表语句详见`\src\main\resources\SQL\init.sql`的后两张表
4. 新建了上述两张表对应的Mapper类
5. 完成了获取在线简历的接口，详情见`\src\main\resources\document\api文档.md`里的内容
6. 整理了项目至今用到的数据库表建表语句，一共四张，在上面说的`init.sql`里，后续有建表可以在里面加，方便开发

pr描述里的内容和readme中新增的日志内容是一样的