### PR TITLE
分页模糊查询岗位

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/com/ShiXi/controller/JobController.java
+++ b/src/main/java/com/ShiXi/controller/JobController.java
@@ -1,5 +1,6 @@
 package com.ShiXi.controller;
 
+import com.ShiXi.dto.JobFuzzyQueryDTO;
 import com.ShiXi.dto.JobPageQueryDTO;
 import com.ShiXi.dto.Result;
 import com.ShiXi.service.JobService;
@@ -33,6 +34,15 @@ public class JobController {
         return jobService.queryById(id);
     }
 
+    /**
+     * 模糊查询Job信息
+     * @param  jobFuzzyQueryDTO 模糊查询条件
+     * @return 模糊查询结果
+     */
+    @GetMapping("/fuzzyQuery")
+    public Result fuzzyQuery(@RequestBody JobFuzzyQueryDTO jobFuzzyQueryDTO){
+        return jobService.fuzzyQuery(jobFuzzyQueryDTO);
+    }
     @PostMapping("/deliverResume")
     public Result deliverResume(@RequestParam("id")Long id){
         return jobService.deliverResume(id);

--- a/src/main/java/com/ShiXi/dto/JobFuzzyQueryDTO.java
+++ b/src/main/java/com/ShiXi/dto/JobFuzzyQueryDTO.java
@@ -1,0 +1,17 @@
+package com.ShiXi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 模糊查询的查询类
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class JobFuzzyQueryDTO {
+    String keyWord;
+    Integer page;
+    Integer pageSize;
+}

--- a/src/main/java/com/ShiXi/service/JobService.java
+++ b/src/main/java/com/ShiXi/service/JobService.java
@@ -1,5 +1,6 @@
 package com.ShiXi.service;
 
+import com.ShiXi.dto.JobFuzzyQueryDTO;
 import com.ShiXi.dto.JobPageQueryDTO;
 import com.ShiXi.dto.Result;
 import com.ShiXi.entity.Job;
@@ -16,4 +17,11 @@ public interface JobService extends IService<Job> {
     Result queryById(Long id);
 
     Result deliverResume(Long id);
+
+    /**
+     * 到数据库中模糊查询
+     * @param jobFuzzyQueryDTO 查询条件
+     * @return 查询结果
+     */
+    Result fuzzyQuery(JobFuzzyQueryDTO jobFuzzyQueryDTO);
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,11 +8,11 @@ spring:
     driver-class-name: com.mysql.jdbc.Driver
     url: jdbc:mysql://127.0.0.1:3306/shixi?useSSL=false&serverTimezone=UTC
     username: root
-    password: 12345678
+    password: 1234
   redis:
-    host: 192.168.36.129
+    host: 192.168.202.128
     port: 6379
-    password: 111111
+    password: 1234
     lettuce:
       pool:
         max-active: 10


### PR DESCRIPTION
1. 添加分页模糊查询岗位的功能
2. 分页查询的问题似乎还没有解决，但pagesize是0的时候records为空，只要pagesize不为0，返回的都是全量的结果，无论pagesize是否为0.total显示的都是全量结果的数量，如下面两张图
![微信截图_20250519185044](https://github.com/user-attachments/assets/76e40c12-5ef9-4760-96b4-e825c24c68e7)
![微信截图_20250519185116](https://github.com/user-attachments/assets/32e948bf-b0d6-4d2d-b7bd-f9a22eb7675b)

