### PR TITLE
添加头像相关接口

### DIFF
--- a/src/main/java/com/ShiXi/config/OSSClientConfig.java
+++ b/src/main/java/com/ShiXi/config/OSSClientConfig.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Configuration;
 public class OSSClientConfig {
     // 从配置文件读取 OSS 信息
 
-    @Value("${spring.oss.endpoint")
+    @Value("${spring.oss.endpoint}")
     private String endpoint;
 
     @Value("${spring.oss.accessKeyId}")

--- a/src/main/java/com/ShiXi/controller/IconController.java
+++ b/src/main/java/com/ShiXi/controller/IconController.java
@@ -1,0 +1,89 @@
+package com.ShiXi.controller;
+
+import com.ShiXi.dto.Result;
+import com.ShiXi.service.IconService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.Resource;
+
+/**
+ * 用来提供与用户头像的上传等相关的服务
+ */
+@Slf4j
+@RestController
+@RequestMapping("/icon")
+@Api(tags = "头像相关接口")
+public class IconController {
+
+    @Resource
+    private IconService iconService;
+
+    /**
+     * 上传用户头像
+     * @param file 头像文件
+     * @return 上传结果
+     */
+    @PostMapping("/upload")
+    @ApiOperation("上传用户头像")
+    public Result uploadAvatar(@RequestParam("file") MultipartFile file) {
+        return iconService.uploadAvatar(file);
+    }
+
+    /**
+     * 删除用户头像
+     * @param avatarUrl 头像URL
+     * @return 删除结果
+     */
+    @DeleteMapping("/delete")
+    @ApiOperation("删除用户头像")
+    public Result deleteAvatar(@RequestParam("avatarUrl") String avatarUrl) {
+        return iconService.deleteAvatar(avatarUrl);
+    }
+
+    /**
+     * 获取用户当前头像
+     * @return 头像信息
+     */
+    @GetMapping("/current")
+    @ApiOperation("获取用户当前头像")
+    public Result getCurrentAvatar() {
+        return iconService.getCurrentAvatar();
+    }
+
+    /**
+     * 更新用户头像信息
+     * @param avatarUrl 头像URL
+     * @return 更新结果
+     */
+    @PutMapping("/update")
+    @ApiOperation("更新用户头像信息")
+    public Result updateUserAvatar(@RequestParam("avatarUrl") String avatarUrl) {
+        return iconService.updateUserAvatar(avatarUrl);
+    }
+    
+    /**
+     * 检查头像文件是否存在
+     * @param avatarUrl 头像URL
+     * @return 检查结果
+     */
+    @GetMapping("/check")
+    @ApiOperation("检查头像文件是否存在")
+    public Result checkAvatarExists(@RequestParam("avatarUrl") String avatarUrl) {
+        return iconService.checkAvatarExists(avatarUrl);
+    }
+    
+    /**
+     * 获取头像预览URL
+     * @param avatarUrl 头像URL
+     * @return 预览URL
+     */
+    @GetMapping("/preview")
+    @ApiOperation("获取头像预览URL")
+    public Result getAvatarPreviewUrl(@RequestParam("avatarUrl") String avatarUrl) {
+        return iconService.getAvatarPreviewUrl(avatarUrl);
+    }
+}

--- a/src/main/java/com/ShiXi/service/IconService.java
+++ b/src/main/java/com/ShiXi/service/IconService.java
@@ -1,0 +1,51 @@
+package com.ShiXi.service;
+
+import com.ShiXi.dto.Result;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 头像相关服务接口
+ */
+public interface IconService {
+    
+    /**
+     * 上传用户头像
+     * @param file 头像文件
+     * @return 上传结果，包含头像URL
+     */
+    Result uploadAvatar(MultipartFile file);
+    
+    /**
+     * 删除用户头像
+     * @param avatarUrl 头像URL
+     * @return 删除结果
+     */
+    Result deleteAvatar(String avatarUrl);
+    
+    /**
+     * 获取用户当前头像
+     * @return 头像信息
+     */
+    Result getCurrentAvatar();
+    
+    /**
+     * 更新用户头像信息到数据库
+     * @param avatarUrl 头像URL
+     * @return 更新结果
+     */
+    Result updateUserAvatar(String avatarUrl);
+    
+    /**
+     * 检查头像文件是否存在
+     * @param avatarUrl 头像URL
+     * @return 检查结果
+     */
+    Result checkAvatarExists(String avatarUrl);
+    
+    /**
+     * 获取头像预览URL（临时访问链接）
+     * @param avatarUrl 头像URL
+     * @return 预览URL
+     */
+    Result getAvatarPreviewUrl(String avatarUrl);
+} 

--- a/src/main/java/com/ShiXi/service/impl/IconServiceImpl.java
+++ b/src/main/java/com/ShiXi/service/impl/IconServiceImpl.java
@@ -1,0 +1,292 @@
+package com.ShiXi.service.impl;
+
+import com.ShiXi.dto.Result;
+import com.ShiXi.dto.UserDTO;
+import com.ShiXi.entity.User;
+import com.ShiXi.service.IconService;
+import com.ShiXi.service.UserService;
+import com.ShiXi.utils.OSSUtil;
+import com.ShiXi.utils.UserHolder;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.Resource;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 头像服务实现类
+ */
+@Slf4j
+@Service
+public class IconServiceImpl implements IconService {
+    
+    @Resource
+    private OSSUtil ossUtil;
+    
+    @Resource
+    private UserService userService;
+    
+    @Resource
+    private com.aliyun.oss.OSS ossClient;
+    
+    @org.springframework.beans.factory.annotation.Value("${spring.oss.bucketName}")
+    private String bucketName;
+    
+    // 头像存储目录
+    private static final String AVATAR_DIR = "avatar/";
+    
+    @Override
+    public Result uploadAvatar(MultipartFile file) {
+        try {
+            // 参数校验
+            if (file == null || file.isEmpty()) {
+                return Result.fail("请选择要上传的头像文件");
+            }
+            
+            // 检查文件类型
+            String originalFilename = file.getOriginalFilename();
+            if (!isValidImageFile(originalFilename)) {
+                return Result.fail("只支持jpg、jpeg、png、gif格式的图片文件");
+            }
+            
+            // 检查文件大小（限制为5MB）
+            if (file.getSize() > 5 * 1024 * 1024) {
+                return Result.fail("头像文件大小不能超过5MB");
+            }
+            
+            // 上传到OSS
+            String avatarUrl = ossUtil.uploadAvatar(file, AVATAR_DIR);
+            
+            // 更新用户头像信息到数据库
+            Result updateResult = updateUserAvatar(avatarUrl);
+            if (!updateResult.getSuccess()) {
+                return updateResult;
+            }
+            
+            // 返回成功结果
+            Map<String, Object> result = new HashMap<>();
+            result.put("avatarUrl", avatarUrl);
+            result.put("message", "头像上传成功");
+            
+            return Result.ok(result);
+            
+        } catch (IOException e) {
+            log.error("头像上传失败", e);
+            return Result.fail("头像上传失败：" + e.getMessage());
+        } catch (Exception e) {
+            log.error("头像上传过程中发生异常", e);
+            return Result.fail("头像上传失败，请稍后重试");
+        }
+    }
+    
+    @Override
+    public Result deleteAvatar(String avatarUrl) {
+        try {
+            // 参数校验
+            if (avatarUrl == null || avatarUrl.trim().isEmpty()) {
+                return Result.fail("头像URL不能为空");
+            }
+            
+            // 从URL中提取文件名
+            String fileName = extractFileNameFromUrl(avatarUrl);
+            if (fileName == null) {
+                return Result.fail("无效的头像URL");
+            }
+            
+            // 删除OSS上的文件
+            ossUtil.deleteFile(fileName);
+            
+            // 清除用户头像信息
+            Result clearResult = updateUserAvatar("");
+            if (!clearResult.getSuccess()) {
+                return clearResult;
+            }
+            
+            return Result.ok("头像删除成功");
+            
+        } catch (Exception e) {
+            log.error("头像删除失败", e);
+            return Result.fail("头像删除失败：" + e.getMessage());
+        }
+    }
+    
+    @Override
+    public Result getCurrentAvatar() {
+        try {
+            // 获取当前登录用户
+            UserDTO currentUser = UserHolder.getUser();
+            if (currentUser == null) {
+                return Result.fail("用户未登录");
+            }
+            
+            // 查询用户信息
+            User user = userService.getById(currentUser.getId());
+            if (user == null) {
+                return Result.fail("用户信息不存在");
+            }
+            
+            Map<String, Object> result = new HashMap<>();
+            result.put("avatarUrl", user.getIcon());
+            result.put("userId", user.getId());
+            result.put("nickName", user.getNickName());
+            
+            return Result.ok(result);
+            
+        } catch (Exception e) {
+            log.error("获取用户头像失败", e);
+            return Result.fail("获取头像信息失败");
+        }
+    }
+    
+    @Override
+    public Result updateUserAvatar(String avatarUrl) {
+        try {
+            // 获取当前登录用户
+            UserDTO currentUser = UserHolder.getUser();
+            if (currentUser == null) {
+                return Result.fail("用户未登录");
+            }
+            
+            // 更新用户头像信息
+            User user = userService.getById(currentUser.getId());
+            if (user == null) {
+                return Result.fail("用户信息不存在");
+            }
+            
+            user.setIcon(avatarUrl);
+            userService.updateById(user);
+            
+            // 更新ThreadLocal中的用户信息
+            currentUser.setIcon(avatarUrl);
+            UserHolder.saveUser(currentUser);
+            
+            return Result.ok("头像信息更新成功");
+            
+        } catch (Exception e) {
+            log.error("更新用户头像信息失败", e);
+            return Result.fail("更新头像信息失败");
+        }
+    }
+    
+    /**
+     * 检查是否为有效的图片文件
+     */
+    private boolean isValidImageFile(String filename) {
+        if (filename == null) return false;
+        String lowerFilename = filename.toLowerCase();
+        return lowerFilename.endsWith(".jpg") || 
+               lowerFilename.endsWith(".jpeg") || 
+               lowerFilename.endsWith(".png") || 
+               lowerFilename.endsWith(".gif");
+    }
+    
+    /**
+     * 从URL中提取OSS文件路径
+     * OSS文件路径通常包含前缀，如 avatar/xxx.jpg
+     */
+    private String extractFileNameFromUrl(String avatarUrl) {
+        if (avatarUrl == null || avatarUrl.trim().isEmpty()) {
+            return null;
+        }
+        
+        try {
+            // 移除URL协议和域名部分，只保留路径
+            String filePath = avatarUrl;
+            
+            // 如果是完整的HTTP/HTTPS URL，提取路径部分
+            if (avatarUrl.startsWith("http://") || avatarUrl.startsWith("https://")) {
+                // 找到域名后的第一个斜杠
+                int domainEndIndex = avatarUrl.indexOf("/", 8); // 跳过 http:// 或 https://
+                if (domainEndIndex != -1) {
+                    filePath = avatarUrl.substring(domainEndIndex + 1);
+                }
+            }
+            
+            // 如果路径以斜杠开头，去掉开头的斜杠
+            if (filePath.startsWith("/")) {
+                filePath = filePath.substring(1);
+            }
+            
+            // 如果文件名包含查询参数，去掉查询参数
+            if (filePath.contains("?")) {
+                filePath = filePath.substring(0, filePath.indexOf("?"));
+            }
+            
+            // 如果文件名包含锚点，去掉锚点
+            if (filePath.contains("#")) {
+                filePath = filePath.substring(0, filePath.indexOf("#"));
+            }
+            
+            // 确保返回的是完整的OSS文件路径（包含前缀）
+            return filePath.isEmpty() ? null : filePath;
+            
+        } catch (Exception e) {
+            log.error("解析头像URL失败", e);
+            return null;
+        }
+    }
+    
+    @Override
+    public Result checkAvatarExists(String avatarUrl) {
+        try {
+            // 参数校验
+            if (avatarUrl == null || avatarUrl.trim().isEmpty()) {
+                return Result.fail("头像URL不能为空");
+            }
+            
+            // 从URL中提取文件名
+            String fileName = extractFileNameFromUrl(avatarUrl);
+            if (fileName == null) {
+                return Result.fail("无效的头像URL");
+            }
+            
+            // 检查文件是否存在
+            boolean exists = ossClient.doesObjectExist(bucketName, fileName);
+            
+            Map<String, Object> result = new HashMap<>();
+            result.put("exists", exists);
+            result.put("fileName", fileName);
+            
+            return Result.ok(result);
+            
+        } catch (Exception e) {
+            log.error("检查头像文件是否存在失败", e);
+            return Result.fail("检查头像文件失败：" + e.getMessage());
+        }
+    }
+    
+    @Override
+    public Result getAvatarPreviewUrl(String avatarUrl) {
+        try {
+            // 参数校验
+            if (avatarUrl == null || avatarUrl.trim().isEmpty()) {
+                return Result.fail("头像URL不能为空");
+            }
+            
+            // 从URL中提取文件名
+            String fileName = extractFileNameFromUrl(avatarUrl);
+            if (fileName == null) {
+                return Result.fail("无效的头像URL");
+            }
+            
+            // 生成临时访问URL（1小时有效）
+            Date expiration = new Date(System.currentTimeMillis() + 60 * 60 * 1000);
+            URL previewUrl = ossClient.generatePresignedUrl(bucketName, fileName, expiration);
+            
+            Map<String, Object> result = new HashMap<>();
+            result.put("previewUrl", previewUrl != null ? previewUrl.toString() : null);
+            result.put("expiration", expiration);
+            
+            return Result.ok(result);
+            
+        } catch (Exception e) {
+            log.error("获取头像预览URL失败", e);
+            return Result.fail("获取头像预览URL失败：" + e.getMessage());
+        }
+    }
+} 

--- a/src/main/java/com/ShiXi/utils/OSSUtil.java
+++ b/src/main/java/com/ShiXi/utils/OSSUtil.java
@@ -1,0 +1,72 @@
+package com.ShiXi.utils;
+
+import com.aliyun.oss.OSS;
+import com.aliyun.oss.model.CannedAccessControlList;
+import com.aliyun.oss.model.PutObjectRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.annotation.Resource;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * 阿里云OSS工具类，支持头像等文件的上传、删除、获取访问URL
+ */
+@Component
+public class OSSUtil {
+    @Resource
+    private OSS ossClient;
+
+    @Value("${spring.oss.bucketName}")
+    private String bucketName;
+
+    @Value("${spring.oss.endpoint}")
+    private String endpoint;
+
+    /**
+     * 上传用户头像到OSS
+     *
+     * @param file 头像文件
+     * @param dir  存储目录（如 avatar/）
+     * @return 文件在OSS中的完整访问URL
+     * @throws IOException IO异常
+     */
+    public String uploadAvatar(MultipartFile file, String dir) throws IOException {
+        // 生成唯一文件名
+        String originalFilename = file.getOriginalFilename();
+        String suffix = originalFilename != null && originalFilename.contains(".") ? originalFilename.substring(originalFilename.lastIndexOf('.')) : "";
+        String fileName = dir + UUID.randomUUID() + suffix;
+        // 上传到OSS
+        ossClient.putObject(new PutObjectRequest(bucketName, fileName, file.getInputStream()));
+        // 设置文件为公共读
+        ossClient.setObjectAcl(bucketName, fileName, CannedAccessControlList.PublicRead);
+        // 返回访问URL
+        return getFileUrl(fileName);
+    }
+
+    /**
+     * 删除OSS上的文件
+     *
+     * @param fileName 文件名（带目录）
+     */
+    public void deleteFile(String fileName) {
+        ossClient.deleteObject(bucketName, fileName);
+    }
+
+    /**
+     * 获取文件的外链URL（默认1年有效）
+     *
+     * @param fileName 文件名（带目录）
+     * @return 访问URL
+     */
+    public String getFileUrl(String fileName) {
+        // 生成带签名的URL，有效期1年
+        Date expiration = new Date(System.currentTimeMillis() + 365L * 24 * 60 * 60 * 1000);
+        URL url = ossClient.generatePresignedUrl(bucketName, fileName, expiration);
+        return url != null ? url.toString() : null;
+    }
+} 

--- a/src/main/java/com/ShiXi/utils/RefreshTokenInterceptor.java
+++ b/src/main/java/com/ShiXi/utils/RefreshTokenInterceptor.java
@@ -31,7 +31,7 @@ public class RefreshTokenInterceptor implements HandlerInterceptor {
         String key  = LOGIN_USER_KEY + token;
         String jsonStr = stringRedisTemplate.opsForValue().get(key);
         // 3.判断用户是否存在
-        if (jsonStr.isEmpty()) {
+        if (jsonStr == null || jsonStr.isEmpty()) {
             return true;
         }
         // 5.将查询到的hash数据转为UserDTO

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -2,6 +2,10 @@ server:
   port: 8081
 
 spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
   application:
     name: ShiXi
   datasource:
@@ -20,6 +24,11 @@ spring:
         max-idle: 10    # 最大空闲连接数
         min-idle: 1     # 最小空闲连接数
         time-between-eviction-runs: 10s  # 空闲连接检测周期
+  oss:
+    endpoint: oss-cn-hangzhou.aliyuncs.com
+    accessKeyId:
+    accessKeySecret:
+    bucketName: dev-env-oss
   jackson:
     default-property-inclusion: non_null # JSON处理时忽略非空字段
 mybatis-plus:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -2,23 +2,33 @@ server:
   port: 8081
 
 spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
   application:
     name: ShiXi
-    datasource:
-      driver-class-name: com.mysql.jdbc.Driver
-      url: jdbc:mysql://127.0.0.1:3306/shixi?useSSL=false&serverTimezone=UTC
-      username: root
-      password: 1234
+  datasource:
+    driver-class-name: com.mysql.jdbc.Driver
+    url: jdbc:mysql://127.0.0.1:3306/shixi?useSSL=false&serverTimezone=UTC
+    username: root
+    password: 1234
   redis:
     host: 192.168.202.128
     port: 6379
     password: 1234
+    username:
     lettuce:
       pool:
         max-active: 10
         max-idle: 10
         min-idle: 1
         time-between-eviction-runs: 10s
+  oss:
+    endpoint: oss-cn-hangzhou.aliyuncs.com
+    accessKeyId:
+    accessKeySecret:
+    bucketName: dev-env-oss
   jackson:
     default-property-inclusion: non_null # JSON处理时忽略非空字段
 mybatis-plus:


### PR DESCRIPTION
本次 PR 新增了 `IconController` 下的六个用户头像管理接口，具体包括：

1. **上传用户头像**  
   - 接口：`POST /icon/upload`  
   - 功能：用户上传头像图片，图片将存储至 OSS，并返回头像访问 URL，并更新至数据库。

2. **删除用户头像**  
   - 接口：`DELETE /icon/delete`  
   - 功能：根据头像 URL 删除指定的头像文件。

3. **获取用户当前头像**  
   - 接口：`GET /icon/current`  
   - 功能：获取当前登录用户的头像信息，包括头像 URL、用户 ID、昵称。

4. **更新用户头像信息**  
   - 接口：`PUT /icon/update`  
   - 功能：更新当前用户的头像信息（如数据库中的头像 URL 字段）
   - （估计不会用这个接口，因为第一个接口已经有了更新数据库的功能，但先写在这里，以免后面要）。

5. **检查头像文件是否存在**  
   - 接口：`GET /icon/check`  
   - 功能：校验指定头像文件在 OSS 上是否存在。

6. **获取头像预览 URL**  
   - 接口：`GET /icon/preview`  
   - 功能：生成头像的临时预览链接（如 1 小时有效），便于用户临时查看头像效果。
---
主要写了IconController、IconService 及其实现类（IconServiceImpl）、OSS 工具类(OSSUtil)，以及相关的配置文件
